### PR TITLE
Added opportunity to store large bitmaps in program memory of ARM processors

### DIFF
--- a/TinyScreen.cpp
+++ b/TinyScreen.cpp
@@ -313,7 +313,7 @@ void TinyScreen::writePixel(uint16_t color) {
   endTransfer();
 }
 
-void TinyScreen::writeBuffer(uint8_t *buffer,int count) {
+void TinyScreen::writeBuffer(const uint8_t *buffer,int count) {
   uint8_t temp;
   TS_SPI_SET_DATA_REG(buffer[0]);
   for(int j=1;j<count;j++){

--- a/TinyScreen.h
+++ b/TinyScreen.h
@@ -159,7 +159,7 @@ class TinyScreen : public Print {
   void clearScreen(void);
   //basic graphics commands
   void writePixel(uint16_t);
-  void writeBuffer(uint8_t *, int);
+  void writeBuffer(const uint8_t *, int);
   void setX(uint8_t, uint8_t);
   void setY(uint8_t, uint8_t);
   void goTo(uint8_t x, uint8_t y);

--- a/examples/TinyScreenBasicExample/TinyScreenBasicExample.ino
+++ b/examples/TinyScreenBasicExample/TinyScreenBasicExample.ino
@@ -23,7 +23,7 @@
 TinyScreen display = TinyScreen(TinyScreenPlus);
 
 //This is an example 17x12 pixel bitmap using TS library color definitions
-unsigned char flappyBirdBitmap[204]={
+const unsigned char flappyBirdBitmap[204]={
   TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Black,TS_8b_Black,TS_8b_Black,TS_8b_Black,TS_8b_Black,TS_8b_Black,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,
   TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Black,TS_8b_Black,TS_8b_White,TS_8b_White,TS_8b_White,TS_8b_Black,TS_8b_White,TS_8b_White,TS_8b_Black,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,
   TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,TS_8b_Black,TS_8b_White,TS_8b_White,TS_8b_Yellow,TS_8b_Yellow,TS_8b_Black,TS_8b_White,TS_8b_White,TS_8b_White,TS_8b_White,TS_8b_Black,TS_8b_Blue,TS_8b_Blue,TS_8b_Blue,


### PR DESCRIPTION
Added opportunity to store large bitmaps in program memory of ARM processors, not in RAM. Description: ARM compiler ignore PROGMEM keyword and automatically move data to program memory freeing RAM. This change allows us to store much more bitmaps in TinyScreen memory and do not waste RAM